### PR TITLE
Set default config stripeModel

### DIFF
--- a/src/Http/Controllers/DatabaseSubscriptionsController.php
+++ b/src/Http/Controllers/DatabaseSubscriptionsController.php
@@ -12,7 +12,7 @@ class DatabaseSubscriptionsController extends Controller
      */
     public function show($billableId)
     {
-        $stripeModel = $this->config->get('cashier.model');
+        $stripeModel = $this->config->get('cashier.model', 'App\User');
 
         /** @var \Illuminate\Database\Eloquent\Model $billableModel */
         $billableModel = (new $stripeModel());


### PR DESCRIPTION
On a Cashier 13 upgrade, the config variable 'cashier.model' could be null.
So, to avoid "Class name must be a valid object or a string" error, would be useful to set a default config value to 'App\User'.